### PR TITLE
Add configurable mod name wrapper

### DIFF
--- a/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
+++ b/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
@@ -9,6 +9,7 @@ import mcp.mobius.waila.utils.Constants;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import org.apache.commons.lang3.StringEscapeUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -159,7 +160,8 @@ public class ConfigHandler implements IWailaConfigHandler {
         OverlayConfig.fontcolor = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_FONTCOLOR, 0xA0A0A0).getInt();
         OverlayConfig.scale = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_SCALE, 100).getInt() / 100.0f;
 
-        VanillaTooltipHandler.namePrefix = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_NAMEPREFIX, "\u00a79\u00a7o").getString();
+
+        VanillaTooltipHandler.namePrefix = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_NAMEPREFIX, StringEscapeUtils.escapeJava("\u00a79\u00a7o")).getString();
 
         HUDHandlerEntities.nhearts = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_NHEARTS, 20).getInt();
         HUDHandlerEntities.maxhpfortext = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_MAXHP, 40).getInt();

--- a/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
+++ b/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
@@ -161,7 +161,8 @@ public class ConfigHandler implements IWailaConfigHandler {
         OverlayConfig.scale = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_SCALE, 100).getInt() / 100.0f;
 
 
-        VanillaTooltipHandler.namePrefix = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_NAMEPREFIX, StringEscapeUtils.escapeJava("\u00a79\u00a7o")).getString();
+        config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_NAMEPREFIX, StringEscapeUtils.escapeJava("\u00a79\u00a7o")).getString();
+        VanillaTooltipHandler.namePrefix = String.valueOf(StringEscapeUtils.UNESCAPE_JAVA);
 
         HUDHandlerEntities.nhearts = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_NHEARTS, 20).getInt();
         HUDHandlerEntities.maxhpfortext = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_MAXHP, 40).getInt();

--- a/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
+++ b/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
@@ -161,8 +161,7 @@ public class ConfigHandler implements IWailaConfigHandler {
         OverlayConfig.scale = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_SCALE, 100).getInt() / 100.0f;
 
 
-        config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_NAMEPREFIX, StringEscapeUtils.escapeJava("\u00a79\u00a7o")).getString();
-        VanillaTooltipHandler.namePrefix = String.valueOf(StringEscapeUtils.UNESCAPE_JAVA);
+        VanillaTooltipHandler.namePrefix = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_NAMEPREFIX, StringEscapeUtils.escapeJava("\u00a79\u00a7o")).getString());
 
         HUDHandlerEntities.nhearts = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_NHEARTS, 20).getInt();
         HUDHandlerEntities.maxhpfortext = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_MAXHP, 40).getInt();

--- a/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
+++ b/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
@@ -160,9 +160,7 @@ public class ConfigHandler implements IWailaConfigHandler {
         OverlayConfig.fontcolor = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_FONTCOLOR, 0xA0A0A0).getInt();
         OverlayConfig.scale = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_SCALE, 100).getInt() / 100.0f;
 
-
-        VanillaTooltipHandler.namePrefix = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_NAMEPREFIX, StringEscapeUtils.escapeJava("\u00a79\u00a7o")).getString());
-        VanillaTooltipHandler.nameSuffix = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_NAMESUFFIX, StringEscapeUtils.escapeJava("\u00a7r")).getString());
+        VanillaTooltipHandler.modNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_MODNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00a79\u00a7o%s")).getString());
 
         HUDHandlerEntities.nhearts = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_NHEARTS, 20).getInt();
         HUDHandlerEntities.maxhpfortext = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_MAXHP, 40).getInt();

--- a/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
+++ b/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
@@ -162,6 +162,7 @@ public class ConfigHandler implements IWailaConfigHandler {
 
 
         VanillaTooltipHandler.namePrefix = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_NAMEPREFIX, StringEscapeUtils.escapeJava("\u00a79\u00a7o")).getString());
+        VanillaTooltipHandler.nameSuffix = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_NAMESUFFIX, StringEscapeUtils.escapeJava("\u00a7r")).getString());
 
         HUDHandlerEntities.nhearts = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_NHEARTS, 20).getInt();
         HUDHandlerEntities.maxhpfortext = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_MAXHP, 40).getInt();

--- a/src/main/java/mcp/mobius/waila/handlers/HUDHandlerBlocks.java
+++ b/src/main/java/mcp/mobius/waila/handlers/HUDHandlerBlocks.java
@@ -84,7 +84,7 @@ public class HUDHandlerBlocks implements IWailaDataProvider {
 
         String modName = ModIdentification.nameFromStack(itemStack);
         if (!Strings.isNullOrEmpty(modName))
-            currenttip.add(VanillaTooltipHandler.namePrefix + modName + VanillaTooltipHandler.nameSuffix);
+            currenttip.add(String.format(VanillaTooltipHandler.modNameWrapper, modName));
 
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/handlers/HUDHandlerBlocks.java
+++ b/src/main/java/mcp/mobius/waila/handlers/HUDHandlerBlocks.java
@@ -84,7 +84,7 @@ public class HUDHandlerBlocks implements IWailaDataProvider {
 
         String modName = ModIdentification.nameFromStack(itemStack);
         if (!Strings.isNullOrEmpty(modName))
-            currenttip.add(VanillaTooltipHandler.namePrefix + modName);
+            currenttip.add(VanillaTooltipHandler.namePrefix + modName + VanillaTooltipHandler.nameSuffix);
 
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/handlers/HUDHandlerEntities.java
+++ b/src/main/java/mcp/mobius/waila/handlers/HUDHandlerEntities.java
@@ -62,9 +62,9 @@ public class HUDHandlerEntities implements IWailaEntityProvider {
     @Override
     public List<String> getWailaTail(Entity entity, List<String> currenttip, IWailaEntityAccessor accessor, IWailaConfigHandler config) {
         try {
-            currenttip.add(VanillaTooltipHandler.namePrefix + getEntityMod(entity) + VanillaTooltipHandler.nameSuffix);
+            currenttip.add(String.format(VanillaTooltipHandler.modNameWrapper, getEntityMod(entity)));
         } catch (Exception e) {
-            currenttip.add(VanillaTooltipHandler.namePrefix + "Unknown" + VanillaTooltipHandler.nameSuffix);
+            currenttip.add("Unknown");
         }
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/handlers/HUDHandlerEntities.java
+++ b/src/main/java/mcp/mobius/waila/handlers/HUDHandlerEntities.java
@@ -62,9 +62,9 @@ public class HUDHandlerEntities implements IWailaEntityProvider {
     @Override
     public List<String> getWailaTail(Entity entity, List<String> currenttip, IWailaEntityAccessor accessor, IWailaConfigHandler config) {
         try {
-            currenttip.add(BLUE + ITALIC + getEntityMod(entity));
+            currenttip.add(VanillaTooltipHandler.namePrefix + getEntityMod(entity));
         } catch (Exception e) {
-            currenttip.add(BLUE + ITALIC + "Unknown");
+            currenttip.add(VanillaTooltipHandler.namePrefix + "Unknown");
         }
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/handlers/HUDHandlerEntities.java
+++ b/src/main/java/mcp/mobius/waila/handlers/HUDHandlerEntities.java
@@ -62,9 +62,9 @@ public class HUDHandlerEntities implements IWailaEntityProvider {
     @Override
     public List<String> getWailaTail(Entity entity, List<String> currenttip, IWailaEntityAccessor accessor, IWailaConfigHandler config) {
         try {
-            currenttip.add(VanillaTooltipHandler.namePrefix + getEntityMod(entity));
+            currenttip.add(VanillaTooltipHandler.namePrefix + getEntityMod(entity) + VanillaTooltipHandler.nameSuffix);
         } catch (Exception e) {
-            currenttip.add(VanillaTooltipHandler.namePrefix + "Unknown");
+            currenttip.add(VanillaTooltipHandler.namePrefix + "Unknown" + VanillaTooltipHandler.nameSuffix);
         }
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/handlers/HUDHandlerEntities.java
+++ b/src/main/java/mcp/mobius/waila/handlers/HUDHandlerEntities.java
@@ -64,7 +64,7 @@ public class HUDHandlerEntities implements IWailaEntityProvider {
         try {
             currenttip.add(String.format(VanillaTooltipHandler.modNameWrapper, getEntityMod(entity)));
         } catch (Exception e) {
-            currenttip.add("Unknown");
+            currenttip.add(String.format(VanillaTooltipHandler.modNameWrapper, "Unknown"));
         }
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
+++ b/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
@@ -15,8 +15,6 @@ public class VanillaTooltipHandler {
     public void tooltipEvent(ItemTooltipEvent event) {
         String canonicalName = ModIdentification.nameFromStack(event.getItemStack());
         if (!Strings.isNullOrEmpty(canonicalName))
-
             event.getToolTip().add(String.format(VanillaTooltipHandler.modNameWrapper, canonicalName));
-
     }
 }

--- a/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
+++ b/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
@@ -9,12 +9,13 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class VanillaTooltipHandler {
     public static String namePrefix = "\u00a79\u00a7o";
+    public static String nameSuffix = "\u00a7r";
 
     @SubscribeEvent
     @SideOnly(Side.CLIENT)
     public void tooltipEvent(ItemTooltipEvent event) {
         String canonicalName = ModIdentification.nameFromStack(event.getItemStack());
         if (!Strings.isNullOrEmpty(canonicalName))
-            event.getToolTip().add(namePrefix + canonicalName);
+            event.getToolTip().add(namePrefix + canonicalName + nameSuffix);
     }
 }

--- a/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
+++ b/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
@@ -15,8 +15,8 @@ public class VanillaTooltipHandler {
     public void tooltipEvent(ItemTooltipEvent event) {
         String canonicalName = ModIdentification.nameFromStack(event.getItemStack());
         if (!Strings.isNullOrEmpty(canonicalName))
-            String.format(VanillaTooltipHandler.modNameWrapper, canonicalName);
-            event.getToolTip().add(modNameWrapper);
+
+            event.getToolTip().add(String.format(VanillaTooltipHandler.modNameWrapper, canonicalName));
 
     }
 }

--- a/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
+++ b/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
@@ -8,14 +8,15 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class VanillaTooltipHandler {
-    public static String namePrefix = "\u00a79\u00a7o";
-    public static String nameSuffix = "\u00a7r";
+    public static String modNameWrapper = "\u00a79\u00a7o%s";
 
     @SubscribeEvent
     @SideOnly(Side.CLIENT)
     public void tooltipEvent(ItemTooltipEvent event) {
         String canonicalName = ModIdentification.nameFromStack(event.getItemStack());
         if (!Strings.isNullOrEmpty(canonicalName))
-            event.getToolTip().add(namePrefix + canonicalName + nameSuffix);
+            String.format(VanillaTooltipHandler.modNameWrapper, canonicalName);
+            event.getToolTip().add(modNameWrapper);
+
     }
 }

--- a/src/main/java/mcp/mobius/waila/utils/Constants.java
+++ b/src/main/java/mcp/mobius/waila/utils/Constants.java
@@ -18,6 +18,7 @@ public final class Constants {
     public static boolean CFG_DEFAULT_VALUE = true;
     public static String CFG_WAILA_SHOW = "waila.cfg.show";
     public static String CFG_WAILA_NAMEPREFIX = "waila.cfg.nameprefix";
+    public static String CFG_WAILA_NAMESUFFIX = "waila.cfg.namesuffix";
     public static String CFG_WAILA_MODE = "waila.cfg.showmode";
     public static String CFG_WAILA_LIQUID = "waila.cfg.liquid";
     public static String CFG_WAILA_METADATA = "waila.cfg.metadata";

--- a/src/main/java/mcp/mobius/waila/utils/Constants.java
+++ b/src/main/java/mcp/mobius/waila/utils/Constants.java
@@ -17,8 +17,7 @@ public final class Constants {
 
     public static boolean CFG_DEFAULT_VALUE = true;
     public static String CFG_WAILA_SHOW = "waila.cfg.show";
-    public static String CFG_WAILA_NAMEPREFIX = "waila.cfg.nameprefix";
-    public static String CFG_WAILA_NAMESUFFIX = "waila.cfg.namesuffix";
+    public static String CFG_WAILA_MODNAMEWRAPPER = "waila.cfg.modnamewrapper";
     public static String CFG_WAILA_MODE = "waila.cfg.showmode";
     public static String CFG_WAILA_LIQUID = "waila.cfg.liquid";
     public static String CFG_WAILA_METADATA = "waila.cfg.metadata";


### PR DESCRIPTION
Fixes https://github.com/TehNut/Waila-Reborn/issues/1
- Customizable mod name using colour code supporting string.
- Add support for entity mod name wrapping using the same config string.

If I have time I'll add a new config section for customizations, and prepare it for future additions. It'd be nice to make WAILA Reborn the most configurable info tooltip HUD in the community.
