### PR TITLE
Configurable wrappers for metadata, entity, and fluid information

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ This is a list of the primary changes and differences between the official Waila
 * Added a new plugin registration system
     * Use `@WailaPlugin` on an instance of `IWailaPlugin`
     * The annotation can take a String value for a required modid. Blank for any
-* Rewrote portions of `IWailaRegistrar` to be enum based
-    * Old registration methods are still there
-    * It is, in my opinion, a cleaner implementation
 * If fluid tooltips are enabled, they will now attempt to display the fluid inside a bucket.
 * Added native support for displaying tank information
     * Disabled by default so as to not clash with mods adding their own support

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 **Here's What You're Looking At** (Pronounced "Hwhy-la", similar to "Coo-Hwhip")
 
-A fork of [Waila by ProfMobius](https://minecraft.curseforge.com/projects/waila). This fork is allowable under the [license](https://github.com/TehNut/Waila-Reborn/blob/1.10/LICENSE.md).
+A fork of [WAILA](https://minecraft.curseforge.com/projects/waila) by [ProfMobius](https://minecraft.curseforge.com/members/ProfMobius).
+This fork is permitted under the [CC BY-NC-SA 4.0](https://github.com/TehNut/Waila-Reborn/blob/1.10/LICENSE.md) license.
 
 I intend to update this fork quickly and often.
 
@@ -27,7 +28,7 @@ This is a list of the primary changes and differences between the official Waila
     * Did any of you even know this was a thing? I sure didn't
 * Maturity tooltips for crops now work correctly if the crop has a different max age.
 * Added config for the format used to display Block, Entity, and Mod names
-    * You can now change the color, add other text, etc.
+    * You can now wrap custom text around the name, with support for MOTD-like formatting codes.
     * See image below
 * Fixed the ID + Meta tooltip
     * No more `< UNIMPLEMENTED >` in your tooltips

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 **HWYLA** (Pronounced "Hwhy-la", similar to "Coo-Hwhip")
 
 A fork of [WAILA](https://minecraft.curseforge.com/projects/waila) by [ProfMobius](https://minecraft.curseforge.com/members/ProfMobius).
-
 This fork is permitted under the [CC BY-NC-SA 4.0](https://github.com/TehNut/HWYLA/blob/1.10/LICENSE.md) license.
 
 I intend to update this fork quickly and often.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Here's What You're Looking At** (Pronounced "Hwhy-la", similar to "Coo-Hwhip")
 
 A fork of [WAILA](https://minecraft.curseforge.com/projects/waila) by [ProfMobius](https://minecraft.curseforge.com/members/ProfMobius).
-This fork is permitted under the [CC BY-NC-SA 4.0](https://github.com/TehNut/Waila-Reborn/blob/1.10/LICENSE.md) license.
+This fork is permitted under the [CC BY-NC-SA 4.0](https://github.com/TehNut/HWYLA/blob/1.10/LICENSE.md) license.
 
 I intend to update this fork quickly and often.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **Here's What You're Looking At** (Pronounced "Hwhy-la", similar to "Coo-Hwhip")
 
 A fork of [WAILA](https://minecraft.curseforge.com/projects/waila) by [ProfMobius](https://minecraft.curseforge.com/members/ProfMobius).
+
 This fork is permitted under the [CC BY-NC-SA 4.0](https://github.com/TehNut/HWYLA/blob/1.10/LICENSE.md) license.
 
 I intend to update this fork quickly and often.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# HWYLA [![Build Status](http://tehnut.info/jenkins/buildStatus/icon?job=HWYLA/1.10)](http://tehnut.info/jenkins/job/HWYLA/job/1.10/) [![License](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-blue.svg)](https://tldrlegal.com/license/creative-commons-attribution-noncommercial-sharealike-4.0-international-(cc-by-nc-sa-4.0))
+# Here's What You're Looking At [![Build Status](http://tehnut.info/jenkins/buildStatus/icon?job=HWYLA/1.10)](http://tehnut.info/jenkins/job/HWYLA/job/1.10/) [![License](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-blue.svg)](https://tldrlegal.com/license/creative-commons-attribution-noncommercial-sharealike-4.0-international-(cc-by-nc-sa-4.0))
 
-**Here's What You're Looking At** (Pronounced "Hwhy-la", similar to "Coo-Hwhip")
+**HWYLA** (Pronounced "Hwhy-la", similar to "Coo-Hwhip")
 
 A fork of [WAILA](https://minecraft.curseforge.com/projects/waila) by [ProfMobius](https://minecraft.curseforge.com/members/ProfMobius).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# HWYLA [![Build Status](http://tehnut.info/jenkins/buildStatus/icon?job=HWYLA/1.10)](http://tehnut.info/jenkins/job/HWYLA/job/1.10/) [![License](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-blue.svg)](https://tldrlegal.com/license/creative-commons-attribution-noncommercial-sharealike-4.0-international-(cc-by-nc-sa-4.0))
+# Here's What You're Looking At [![Build Status](http://tehnut.info/jenkins/buildStatus/icon?job=HWYLA/1.10)](http://tehnut.info/jenkins/job/HWYLA/job/1.10/) [![License](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-blue.svg)](https://tldrlegal.com/license/creative-commons-attribution-noncommercial-sharealike-4.0-international-(cc-by-nc-sa-4.0))
 
-**Here's What You're Looking At** (Pronounced "Hwhy-la", similar to "Coo-Hwhip")
+**HWYLA** (Pronounced "Hwhy-la", similar to "Coo-Hwhip")
 
 A fork of [WAILA](https://minecraft.curseforge.com/projects/waila) by [ProfMobius](https://minecraft.curseforge.com/members/ProfMobius).
 This fork is permitted under the [CC BY-NC-SA 4.0](https://github.com/TehNut/HWYLA/blob/1.10/LICENSE.md) license.

--- a/src/main/java/mcp/mobius/waila/addons/capability/PluginCapability.java
+++ b/src/main/java/mcp/mobius/waila/addons/capability/PluginCapability.java
@@ -10,9 +10,11 @@ public class PluginCapability implements IWailaPlugin {
 
     @Override
     public void register(IWailaRegistrar registrar) {
+
         registrar.registerBodyProvider(HUDHandlerTank.INSTANCE, TileEntity.class);
         registrar.registerNBTProvider(HUDHandlerTank.INSTANCE, TileEntity.class);
 
         registrar.addConfig("Capability", "capability.tankinfo", false);
+
     }
 }

--- a/src/main/java/mcp/mobius/waila/addons/capability/PluginCapability.java
+++ b/src/main/java/mcp/mobius/waila/addons/capability/PluginCapability.java
@@ -10,11 +10,9 @@ public class PluginCapability implements IWailaPlugin {
 
     @Override
     public void register(IWailaRegistrar registrar) {
-
         registrar.registerBodyProvider(HUDHandlerTank.INSTANCE, TileEntity.class);
         registrar.registerNBTProvider(HUDHandlerTank.INSTANCE, TileEntity.class);
 
         registrar.addConfig("Capability", "capability.tankinfo", false);
-
     }
 }

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerBlocks.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerBlocks.java
@@ -84,8 +84,12 @@ public class HUDHandlerBlocks implements IWailaDataProvider {
             return currenttip;
 
         String modName = ModIdentification.nameFromStack(itemStack);
-        if (!Strings.isNullOrEmpty(modName))
+
+        if (!Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper)) {
+
             currenttip.add(String.format(VanillaTooltipHandler.modNameWrapper, modName));
+
+        }
 
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerBlocks.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerBlocks.java
@@ -59,8 +59,9 @@ public class HUDHandlerBlocks implements IWailaDataProvider {
                     accessor.getMetadata()
             );
 
-            if (ConfigHandler.instance().getConfig(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATA, true))
+            if (ConfigHandler.instance().getConfig(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATA, true) && !Strings.isNullOrEmpty(VanillaTooltipHandler.metaDataWrapper)) {
                 currenttip.add(String.format(VanillaTooltipHandler.metaDataWrapper, metaMetaData));
+            }
         }
 
         return currenttip;

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerBlocks.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerBlocks.java
@@ -57,7 +57,7 @@ public class HUDHandlerBlocks implements IWailaDataProvider {
             currenttip.add("< Unnamed >");
         else {
             if (ConfigHandler.instance().getConfig(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATA, true))
-                currenttip.add(String.format(VanillaTooltipHandler.metaDataWrapper,accessor.getBlock().getRegistryName().toString(), accessor.getMetadata()));
+                currenttip.add(String.format(VanillaTooltipHandler.metaDataThroughput,accessor.getBlock().getRegistryName().toString(), accessor.getMetadata()));
         }
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerBlocks.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerBlocks.java
@@ -59,7 +59,7 @@ public class HUDHandlerBlocks implements IWailaDataProvider {
             currenttip.add("< Unnamed >");
         else {
             if (ConfigHandler.instance().getConfig(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATA, true))
-                currenttip.add(String.format(LPURPLE + "< %s:%d >", accessor.getBlock().getRegistryName().toString(), accessor.getMetadata()));
+                currenttip.add(String.format(LPURPLE + "%s:%d", accessor.getBlock().getRegistryName().toString(), accessor.getMetadata()));
         }
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerBlocks.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerBlocks.java
@@ -39,11 +39,9 @@ public class HUDHandlerBlocks implements IWailaDataProvider {
             String s = DisplayUtil.itemDisplayNameShort(itemStack);
             if (s != null && !s.endsWith("Unnamed"))
                 name = s;
-
             if (name != null)
                 currenttip.add(name);
-        } catch (Exception e) {
-        }
+        } catch (Exception e) {}
 
         if (itemStack.getItem() == Items.REDSTONE) {
             int md = accessor.getMetadata();
@@ -52,24 +50,19 @@ public class HUDHandlerBlocks implements IWailaDataProvider {
                 s = " " + s;
             currenttip.set(currenttip.size() - 1, name + " " + s);
         }
-
         if (currenttip.size() == 0)
             currenttip.add("< Unnamed >");
         else {
-
             String metaMetaData = String.format(
-
                     VanillaTooltipHandler.metaDataThroughput,
                     accessor.getBlock().getRegistryName().toString(),
                     accessor.getMetadata()
-
             );
 
             if (ConfigHandler.instance().getConfig(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATA, true))
-
                 currenttip.add(String.format(VanillaTooltipHandler.metaDataWrapper, metaMetaData));
-
         }
+
         return currenttip;
     }
 
@@ -82,13 +75,9 @@ public class HUDHandlerBlocks implements IWailaDataProvider {
     public List<String> getWailaTail(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor, IWailaConfigHandler config) {
         if (accessor.getBlockState().getMaterial().isLiquid())
             return currenttip;
-
         String modName = ModIdentification.nameFromStack(itemStack);
-
         if (!Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper)) {
-
             currenttip.add(String.format(VanillaTooltipHandler.modNameWrapper, modName));
-
         }
 
         return currenttip;

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerBlocks.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerBlocks.java
@@ -20,8 +20,6 @@ import net.minecraftforge.common.config.Configuration;
 
 import java.util.List;
 
-import static mcp.mobius.waila.api.SpecialChars.*;
-
 public class HUDHandlerBlocks implements IWailaDataProvider {
 
     static final IWailaDataProvider INSTANCE = new HUDHandlerBlocks();
@@ -59,7 +57,7 @@ public class HUDHandlerBlocks implements IWailaDataProvider {
             currenttip.add("< Unnamed >");
         else {
             if (ConfigHandler.instance().getConfig(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATA, true))
-                currenttip.add(String.format(LPURPLE + "%s:%d", accessor.getBlock().getRegistryName().toString(), accessor.getMetadata()));
+                currenttip.add(String.format(VanillaTooltipHandler.metaDataWrapper,accessor.getBlock().getRegistryName().toString(), accessor.getMetadata()));
         }
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerBlocks.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerBlocks.java
@@ -59,7 +59,7 @@ public class HUDHandlerBlocks implements IWailaDataProvider {
             currenttip.add("< Unnamed >");
         else {
             if (ConfigHandler.instance().getConfig(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATA, true))
-                currenttip.add(String.format(ITALIC + "[%s:%d]", accessor.getBlock().getRegistryName().toString(), accessor.getMetadata()));
+                currenttip.add(String.format(LPURPLE + "[%s:%d]", accessor.getBlock().getRegistryName().toString(), accessor.getMetadata()));
         }
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerBlocks.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerBlocks.java
@@ -59,7 +59,7 @@ public class HUDHandlerBlocks implements IWailaDataProvider {
             currenttip.add("< Unnamed >");
         else {
             if (ConfigHandler.instance().getConfig(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATA, true))
-                currenttip.add(String.format(LPURPLE + "[%s:%d]", accessor.getBlock().getRegistryName().toString(), accessor.getMetadata()));
+                currenttip.add(String.format(LPURPLE + "< %s:%d >", accessor.getBlock().getRegistryName().toString(), accessor.getMetadata()));
         }
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerBlocks.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerBlocks.java
@@ -56,8 +56,19 @@ public class HUDHandlerBlocks implements IWailaDataProvider {
         if (currenttip.size() == 0)
             currenttip.add("< Unnamed >");
         else {
+
+            String metaMetaData = String.format(
+
+                    VanillaTooltipHandler.metaDataThroughput,
+                    accessor.getBlock().getRegistryName().toString(),
+                    accessor.getMetadata()
+
+            );
+
             if (ConfigHandler.instance().getConfig(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATA, true))
-                currenttip.add(String.format(VanillaTooltipHandler.metaDataThroughput,accessor.getBlock().getRegistryName().toString(), accessor.getMetadata()));
+
+                currenttip.add(String.format(VanillaTooltipHandler.metaDataWrapper, metaMetaData));
+
         }
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
@@ -9,6 +9,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
@@ -50,7 +51,7 @@ public class HUDHandlerEntities implements IWailaEntityProvider {
                 if (((EntityLivingBase) entity).getMaxHealth() > maxhpfortext) {
                     currenttip.add(
                             String.format(
-                                    "Health : " + WHITE + "%.0f" + GRAY + " / " + WHITE + "%.0f",
+                                    I18n.translateToLocal("hud.msg.health") + ": " + WHITE + "%.0f" + GRAY + " / " + WHITE + "%.0f",
                                     ((EntityLivingBase) entity).getHealth(),
                                     ((EntityLivingBase) entity).getMaxHealth()
                             )

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
@@ -83,7 +83,7 @@ public class HUDHandlerEntities implements IWailaEntityProvider {
     @Override
     public List<String> getWailaTail(Entity entity, List<String> currenttip, IWailaEntityAccessor accessor, IWailaConfigHandler config) {
 
-        if (!Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper)) {
+        if (!Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper) && !Strings.isNullOrEmpty(getEntityMod(entity))) {
 
             try {
 

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
@@ -52,7 +52,7 @@ public class HUDHandlerEntities implements IWailaEntityProvider {
             float maxhp = ((EntityLivingBase) entity).getMaxHealth() / 2.0f;
 
             if (((EntityLivingBase) entity).getMaxHealth() > maxhpfortext)
-                currenttip.add(String.format("HP : " + WHITE + "%.0f" + GRAY + " / " + WHITE + "%.0f", ((EntityLivingBase) entity).getHealth(), ((EntityLivingBase) entity).getMaxHealth()));
+                currenttip.add(String.format("Health : " + WHITE + "%.0f" + GRAY + " / " + WHITE + "%.0f", ((EntityLivingBase) entity).getHealth(), ((EntityLivingBase) entity).getMaxHealth()));
 
             else {
                 currenttip.add(getRenderString("waila.health", String.valueOf(nhearts), String.valueOf(health), String.valueOf(maxhp)));

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
@@ -32,119 +32,70 @@ public class HUDHandlerEntities implements IWailaEntityProvider {
 
     @Override
     public List<String> getWailaHead(Entity entity, List<String> currenttip, IWailaEntityAccessor accessor, IWailaConfigHandler config) {
-
-        try {
-
-            currenttip.add(String.format(VanillaTooltipHandler.entityNameWrapper, entity.getName()));
-
-        } catch (Exception e) {
-
-            currenttip.add(String.format(VanillaTooltipHandler.entityNameWrapper, "Unknown"));
-
-        }
+        try {currenttip.add(String.format(VanillaTooltipHandler.entityNameWrapper, entity.getName()));}
+        catch (Exception e) {currenttip.add(String.format(VanillaTooltipHandler.entityNameWrapper, "Unknown"));}
 
         return currenttip;
-
     }
 
     @Override
     public List<String> getWailaBody(Entity entity, List<String> currenttip, IWailaEntityAccessor accessor, IWailaConfigHandler config) {
-
         if (config.getConfig("general.showhp") && entity instanceof EntityLivingBase) {
-
-                //String hptip = "";
-
                 nhearts = nhearts <= 0 ? 20 : nhearts;
-
                 float health = ((EntityLivingBase) entity).getHealth() / 2.0f;
                 float maxhp = ((EntityLivingBase) entity).getMaxHealth() / 2.0f;
 
                 if (((EntityLivingBase) entity).getMaxHealth() > maxhpfortext) {
-
                     currenttip.add(
-
                             String.format(
-
                                     "Health : " + WHITE + "%.0f" + GRAY + " / " + WHITE + "%.0f",
                                     ((EntityLivingBase) entity).getHealth(),
                                     ((EntityLivingBase) entity).getMaxHealth()
-
                             )
-
                     );
 
                 } else {
-
                     currenttip.add(
-
                             getRenderString(
-
                                     "waila.health",
                                     String.valueOf(nhearts),
                                     String.valueOf(health),
                                     String.valueOf(maxhp)
-
                             )
-
                     );
-
                 /*if (Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper)) {
-
                     currenttip.add(" ");
-
                 }*/
-
                 }
-
             }
 
             return currenttip;
-
         }
 
     @Override
     public List<String> getWailaTail(Entity entity, List<String> currenttip, IWailaEntityAccessor accessor, IWailaConfigHandler config) {
-
         if (!Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper) && !Strings.isNullOrEmpty(getEntityMod(entity))) {
-
-            try {
-
-                currenttip.add(String.format(VanillaTooltipHandler.modNameWrapper, getEntityMod(entity)));
-
-            } catch (Exception e) {
-
-                currenttip.add(String.format(VanillaTooltipHandler.modNameWrapper, "Unknown"));
-
-            }
-
+            try {currenttip.add(String.format(VanillaTooltipHandler.modNameWrapper, getEntityMod(entity)));}
+            catch (Exception e) {currenttip.add(String.format(VanillaTooltipHandler.modNameWrapper, "Unknown"));}
         }
 
         return currenttip;
-
     }
 
     @Override
     public NBTTagCompound getNBTData(EntityPlayerMP player, Entity te, NBTTagCompound tag, World world) {
         return tag;
     }
-
     private static String getEntityMod(Entity entity) {
 
         String modName = "";
-
         try {
-
             EntityRegistration er = EntityRegistry.instance().lookupModSpawn(entity.getClass(), true);
             ModContainer modC = er.getContainer();
             modName = modC.getName();
-
-        } catch (NullPointerException e) {
-
-            modName = "Minecraft";
         }
+        catch (NullPointerException e) {modName = "Minecraft";}
 
         return modName;
-
     }
-
 }

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
@@ -1,5 +1,6 @@
 package mcp.mobius.waila.addons.core;
 
+import com.google.common.base.Strings;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaEntityAccessor;
 import mcp.mobius.waila.api.IWailaEntityProvider;
@@ -51,11 +52,28 @@ public class HUDHandlerEntities implements IWailaEntityProvider {
             float health = ((EntityLivingBase) entity).getHealth() / 2.0f;
             float maxhp = ((EntityLivingBase) entity).getMaxHealth() / 2.0f;
 
-            if (((EntityLivingBase) entity).getMaxHealth() > maxhpfortext)
-                currenttip.add(String.format("Health : " + WHITE + "%.0f" + GRAY + " / " + WHITE + "%.0f", ((EntityLivingBase) entity).getHealth(), ((EntityLivingBase) entity).getMaxHealth()));
+            if (((EntityLivingBase) entity).getMaxHealth() > maxhpfortext) {
 
+                currenttip.add(
+
+                        String.format(
+
+                                "Health : " + WHITE + "%.0f" + GRAY + " / " + WHITE + "%.0f",
+                                ((EntityLivingBase) entity).getHealth(),
+                                ((EntityLivingBase) entity).getMaxHealth()
+
+                        )
+                );
+
+            }
             else {
+
                 currenttip.add(getRenderString("waila.health", String.valueOf(nhearts), String.valueOf(health), String.valueOf(maxhp)));
+
+                /*if (Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper)) {
+                    currenttip.add(" ");
+                }*/
+
             }
         }
 
@@ -64,12 +82,23 @@ public class HUDHandlerEntities implements IWailaEntityProvider {
 
     @Override
     public List<String> getWailaTail(Entity entity, List<String> currenttip, IWailaEntityAccessor accessor, IWailaConfigHandler config) {
-        try {
-            currenttip.add(String.format(VanillaTooltipHandler.modNameWrapper, getEntityMod(entity)));
-        } catch (Exception e) {
-            currenttip.add(String.format(VanillaTooltipHandler.modNameWrapper, "Unknown"));
+
+        if (!Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper)) {
+
+            try {
+
+                currenttip.add(String.format(VanillaTooltipHandler.modNameWrapper, getEntityMod(entity)));
+
+            } catch (Exception e) {
+
+                currenttip.add(String.format(VanillaTooltipHandler.modNameWrapper, "Unknown"));
+
+            }
+
         }
+
         return currenttip;
+
     }
 
     @Override

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
@@ -65,7 +65,7 @@ public class HUDHandlerEntities implements IWailaEntityProvider {
                                     String.valueOf(maxhp)
                             )
                     );
-                    // Putting a cheap bandage on this until I figure it out.
+                    // Putting a cheat bandage on this until I figure it out.
                 if (Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper)) {
                     currenttip.add(" ");
                 }

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
@@ -32,9 +32,9 @@ public class HUDHandlerEntities implements IWailaEntityProvider {
     @Override
     public List<String> getWailaHead(Entity entity, List<String> currenttip, IWailaEntityAccessor accessor, IWailaConfigHandler config) {
         try {
-            currenttip.add(String.format(VanillaTooltipHandler.objectNameWrapper, entity.getName()));
+            currenttip.add(String.format(VanillaTooltipHandler.entityNameWrapper, entity.getName()));
         } catch (Exception e) {
-            currenttip.add(String.format(VanillaTooltipHandler.objectNameWrapper, "Unknown"));
+            currenttip.add(String.format(VanillaTooltipHandler.entityNameWrapper, "Unknown"));
         }
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
@@ -32,67 +32,75 @@ public class HUDHandlerEntities implements IWailaEntityProvider {
 
     @Override
     public List<String> getWailaHead(Entity entity, List<String> currenttip, IWailaEntityAccessor accessor, IWailaConfigHandler config) {
+
         try {
+
             currenttip.add(String.format(VanillaTooltipHandler.entityNameWrapper, entity.getName()));
+
         } catch (Exception e) {
+
             currenttip.add(String.format(VanillaTooltipHandler.entityNameWrapper, "Unknown"));
+
         }
+
         return currenttip;
+
     }
 
     @Override
     public List<String> getWailaBody(Entity entity, List<String> currenttip, IWailaEntityAccessor accessor, IWailaConfigHandler config) {
-        if (!config.getConfig("general.showhp")) return currenttip;
 
-        if (entity instanceof EntityLivingBase) {
-            String hptip = "";
+        if (config.getConfig("general.showhp") && entity instanceof EntityLivingBase) {
 
-            nhearts = nhearts <= 0 ? 20 : nhearts;
+                //String hptip = "";
 
-            float health = ((EntityLivingBase) entity).getHealth() / 2.0f;
-            float maxhp = ((EntityLivingBase) entity).getMaxHealth() / 2.0f;
+                nhearts = nhearts <= 0 ? 20 : nhearts;
 
-            if (((EntityLivingBase) entity).getMaxHealth() > maxhpfortext) {
+                float health = ((EntityLivingBase) entity).getHealth() / 2.0f;
+                float maxhp = ((EntityLivingBase) entity).getMaxHealth() / 2.0f;
 
-                currenttip.add(
+                if (((EntityLivingBase) entity).getMaxHealth() > maxhpfortext) {
 
-                        String.format(
+                    currenttip.add(
 
-                                "Health : " + WHITE + "%.0f" + GRAY + " / " + WHITE + "%.0f",
-                                ((EntityLivingBase) entity).getHealth(),
-                                ((EntityLivingBase) entity).getMaxHealth()
+                            String.format(
 
-                        )
+                                    "Health : " + WHITE + "%.0f" + GRAY + " / " + WHITE + "%.0f",
+                                    ((EntityLivingBase) entity).getHealth(),
+                                    ((EntityLivingBase) entity).getMaxHealth()
 
-                );
+                            )
 
-            }
-            else {
+                    );
 
-                currenttip.add(
+                } else {
 
-                        getRenderString(
+                    currenttip.add(
 
-                                "waila.health",
-                                String.valueOf(nhearts),
-                                String.valueOf(health),
-                                String.valueOf(maxhp)
+                            getRenderString(
 
-                        )
+                                    "waila.health",
+                                    String.valueOf(nhearts),
+                                    String.valueOf(health),
+                                    String.valueOf(maxhp)
 
-                );
+                            )
 
-                if (Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper)) {
+                    );
+
+                /*if (Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper)) {
 
                     currenttip.add(" ");
+
+                }*/
 
                 }
 
             }
-        }
 
-        return currenttip;
-    }
+            return currenttip;
+
+        }
 
     @Override
     public List<String> getWailaTail(Entity entity, List<String> currenttip, IWailaEntityAccessor accessor, IWailaConfigHandler config) {
@@ -121,14 +129,22 @@ public class HUDHandlerEntities implements IWailaEntityProvider {
     }
 
     private static String getEntityMod(Entity entity) {
+
         String modName = "";
+
         try {
+
             EntityRegistration er = EntityRegistry.instance().lookupModSpawn(entity.getClass(), true);
             ModContainer modC = er.getContainer();
             modName = modC.getName();
+
         } catch (NullPointerException e) {
+
             modName = "Minecraft";
         }
+
         return modName;
+
     }
+
 }

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
@@ -65,9 +65,10 @@ public class HUDHandlerEntities implements IWailaEntityProvider {
                                     String.valueOf(maxhp)
                             )
                     );
-                /*if (Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper)) {
+                    // Putting a cheap bandage on this until I figure it out.
+                if (Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper)) {
                     currenttip.add(" ");
-                }*/
+                }
                 }
             }
 

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
@@ -63,16 +63,30 @@ public class HUDHandlerEntities implements IWailaEntityProvider {
                                 ((EntityLivingBase) entity).getMaxHealth()
 
                         )
+
                 );
 
             }
             else {
 
-                currenttip.add(getRenderString("waila.health", String.valueOf(nhearts), String.valueOf(health), String.valueOf(maxhp)));
+                currenttip.add(
 
-                /*if (Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper)) {
+                        getRenderString(
+
+                                "waila.health",
+                                String.valueOf(nhearts),
+                                String.valueOf(health),
+                                String.valueOf(maxhp)
+
+                        )
+
+                );
+
+                if (Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper)) {
+
                     currenttip.add(" ");
-                }*/
+
+                }
 
             }
         }

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
@@ -32,8 +32,10 @@ public class HUDHandlerEntities implements IWailaEntityProvider {
 
     @Override
     public List<String> getWailaHead(Entity entity, List<String> currenttip, IWailaEntityAccessor accessor, IWailaConfigHandler config) {
-        try {currenttip.add(String.format(VanillaTooltipHandler.entityNameWrapper, entity.getName()));}
-        catch (Exception e) {currenttip.add(String.format(VanillaTooltipHandler.entityNameWrapper, "Unknown"));}
+        if (!Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper)) {
+            try {currenttip.add(String.format(VanillaTooltipHandler.entityNameWrapper, entity.getName()));}
+            catch (Exception e) {currenttip.add(String.format(VanillaTooltipHandler.entityNameWrapper, "Unknown"));}
+        }
 
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerFluids.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerFluids.java
@@ -40,7 +40,7 @@ public class HUDHandlerFluids implements IWailaDataProvider {
         Pair<Fluid, Boolean> fluidPair = getFluidFromBlock(accessor.getBlockState());
         String name = null;
         try {
-            String s = String.format(VanillaTooltipHandler.blockNameWrapper, fluidPair.getLeft().getLocalizedName(new FluidStack(fluidPair.getLeft(), 1000)));
+            String s = String.format(VanillaTooltipHandler.fluidNameWrapper, fluidPair.getLeft().getLocalizedName(new FluidStack(fluidPair.getLeft(), 1000)));
             if (s != null && !s.endsWith("Unnamed"))
                 name = s;
 

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerFluids.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerFluids.java
@@ -53,7 +53,7 @@ public class HUDHandlerFluids implements IWailaDataProvider {
             currenttip.add("< Unnamed >");
         else {
             if (ConfigHandler.instance().getConfig(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATA, true))
-                currenttip.add(String.format(VanillaTooltipHandler.metaDataWrapper, accessor.getBlock().getRegistryName().toString(), accessor.getMetadata()));
+                currenttip.add(String.format(VanillaTooltipHandler.metaDataThroughput, accessor.getBlock().getRegistryName().toString(), accessor.getMetadata()));
         }
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerFluids.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerFluids.java
@@ -26,7 +26,7 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.List;
 
-import static mcp.mobius.waila.api.SpecialChars.ITALIC;
+import static mcp.mobius.waila.api.SpecialChars.LPURPLE;
 
 public class HUDHandlerFluids implements IWailaDataProvider {
 
@@ -55,7 +55,7 @@ public class HUDHandlerFluids implements IWailaDataProvider {
             currenttip.add("< Unnamed >");
         else {
             if (ConfigHandler.instance().getConfig(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATA, true))
-                currenttip.add(String.format(ITALIC + "[%s:%d]", accessor.getBlock().getRegistryName().toString(), accessor.getMetadata()));
+                currenttip.add(String.format(LPURPLE + "%s:%d", accessor.getBlock().getRegistryName().toString(), accessor.getMetadata()));
         }
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerFluids.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerFluids.java
@@ -26,8 +26,6 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.List;
 
-import static mcp.mobius.waila.api.SpecialChars.LPURPLE;
-
 public class HUDHandlerFluids implements IWailaDataProvider {
 
     static final IWailaDataProvider INSTANCE = new HUDHandlerFluids();
@@ -42,7 +40,7 @@ public class HUDHandlerFluids implements IWailaDataProvider {
         Pair<Fluid, Boolean> fluidPair = getFluidFromBlock(accessor.getBlockState());
         String name = null;
         try {
-            String s = String.format(VanillaTooltipHandler.objectNameWrapper, fluidPair.getLeft().getLocalizedName(new FluidStack(fluidPair.getLeft(), 1000)));
+            String s = String.format(VanillaTooltipHandler.blockNameWrapper, fluidPair.getLeft().getLocalizedName(new FluidStack(fluidPair.getLeft(), 1000)));
             if (s != null && !s.endsWith("Unnamed"))
                 name = s;
 
@@ -55,7 +53,7 @@ public class HUDHandlerFluids implements IWailaDataProvider {
             currenttip.add("< Unnamed >");
         else {
             if (ConfigHandler.instance().getConfig(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATA, true))
-                currenttip.add(String.format(LPURPLE + "%s:%d", accessor.getBlock().getRegistryName().toString(), accessor.getMetadata()));
+                currenttip.add(String.format(VanillaTooltipHandler.metaDataWrapper, accessor.getBlock().getRegistryName().toString(), accessor.getMetadata()));
         }
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerFluids.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerFluids.java
@@ -79,8 +79,11 @@ public class HUDHandlerFluids implements IWailaDataProvider {
         Pair<Fluid, Boolean> fluidPair = getFluidFromBlock(accessor.getBlockState());
         String modName = ModIdentification.findModContainer(FluidRegistry.getDefaultFluidName(fluidPair.getLeft()).split(":")[0]).getName();
 
-        if (!Strings.isNullOrEmpty(modName))
-            currenttip.add(String.format(VanillaTooltipHandler.modNameWrapper, modName));
+        if (!Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper)) {
+
+        currenttip.add(String.format(VanillaTooltipHandler.modNameWrapper, modName));
+
+        }
 
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerFluids.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerFluids.java
@@ -79,7 +79,7 @@ public class HUDHandlerFluids implements IWailaDataProvider {
         Pair<Fluid, Boolean> fluidPair = getFluidFromBlock(accessor.getBlockState());
         String modName = ModIdentification.findModContainer(FluidRegistry.getDefaultFluidName(fluidPair.getLeft()).split(":")[0]).getName();
 
-        if (!Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper)) {
+        if (!Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper) && !Strings.isNullOrEmpty(modName)) {
 
         currenttip.add(String.format(VanillaTooltipHandler.modNameWrapper, modName));
 

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerFluids.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerFluids.java
@@ -49,56 +49,43 @@ public class HUDHandlerFluids implements IWailaDataProvider {
         } catch (Exception e) {
         }
 
-        if (currenttip.size() == 0)
-            currenttip.add("< Unnamed >");
+        if (currenttip.size() == 0) currenttip.add("< Unnamed >");
         else {
-
             String metaMetaData = String.format(
-
                     VanillaTooltipHandler.metaDataThroughput,
                     accessor.getBlock().getRegistryName().toString(),
                     accessor.getMetadata()
-
             );
 
             if (ConfigHandler.instance().getConfig(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATA, true))
-
                 currenttip.add(String.format(VanillaTooltipHandler.metaDataWrapper, metaMetaData));
-
         }
+
         return currenttip;
     }
 
     @Override
-    public List<String> getWailaBody(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor, IWailaConfigHandler config) {
-        return null;
-    }
+    public List<String> getWailaBody(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor, IWailaConfigHandler config) {return null;}
 
     @Override
     public List<String> getWailaTail(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor, IWailaConfigHandler config) {
         Pair<Fluid, Boolean> fluidPair = getFluidFromBlock(accessor.getBlockState());
         String modName = ModIdentification.findModContainer(FluidRegistry.getDefaultFluidName(fluidPair.getLeft()).split(":")[0]).getName();
-
         if (!Strings.isNullOrEmpty(VanillaTooltipHandler.modNameWrapper) && !Strings.isNullOrEmpty(modName)) {
-
-        currenttip.add(String.format(VanillaTooltipHandler.modNameWrapper, modName));
-
+            currenttip.add(String.format(VanillaTooltipHandler.modNameWrapper, modName));
         }
 
         return currenttip;
     }
 
     @Override
-    public NBTTagCompound getNBTData(EntityPlayerMP player, TileEntity te, NBTTagCompound tag, World world, BlockPos pos) {
-        return null;
-    }
+    public NBTTagCompound getNBTData(EntityPlayerMP player, TileEntity te, NBTTagCompound tag, World world, BlockPos pos) {return null;}
 
     private static ItemStack getStackFromLiquid(IBlockState state) {
         Pair<Fluid, Boolean> fluidPair = getFluidFromBlock(state);
         Fluid fluid = fluidPair.getLeft();
         boolean vanilla = fluidPair.getRight();
         ItemStack ret = null;
-
         if (fluid != null) {
             if (FluidRegistry.isUniversalBucketEnabled())
                 ret = UniversalBucket.getFilledBucket(ForgeModContainer.getInstance().universalBucket, fluid);
@@ -107,6 +94,7 @@ public class HUDHandlerFluids implements IWailaDataProvider {
             else
                 ret = FluidContainerRegistry.fillFluidContainer(new FluidStack(fluid, 1000), new ItemStack(Items.BUCKET));
         }
+
         return ret != null ? ret : null;
     }
 
@@ -117,8 +105,8 @@ public class HUDHandlerFluids implements IWailaDataProvider {
             Block fluidBlock = BlockLiquid.getStaticBlock(state.getMaterial());
             fluid = fluidBlock == Blocks.WATER ? FluidRegistry.WATER : FluidRegistry.LAVA;
             vanilla = true;
-        } else if (state.getBlock() instanceof IFluidBlock) fluid = ((IFluidBlock) state.getBlock()).getFluid();
-
+        }
+        else if (state.getBlock() instanceof IFluidBlock) fluid = ((IFluidBlock) state.getBlock()).getFluid();
 
         return Pair.of(fluid, vanilla);
     }

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerFluids.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerFluids.java
@@ -57,12 +57,14 @@ public class HUDHandlerFluids implements IWailaDataProvider {
                     accessor.getMetadata()
             );
 
-            if (ConfigHandler.instance().getConfig(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATA, true))
+            if (ConfigHandler.instance().getConfig(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATA, true) && !Strings.isNullOrEmpty(VanillaTooltipHandler.metaDataWrapper)) {
                 currenttip.add(String.format(VanillaTooltipHandler.metaDataWrapper, metaMetaData));
+                }
         }
 
         return currenttip;
     }
+
 
     @Override
     public List<String> getWailaBody(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor, IWailaConfigHandler config) {return null;}

--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerFluids.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerFluids.java
@@ -52,8 +52,19 @@ public class HUDHandlerFluids implements IWailaDataProvider {
         if (currenttip.size() == 0)
             currenttip.add("< Unnamed >");
         else {
+
+            String metaMetaData = String.format(
+
+                    VanillaTooltipHandler.metaDataThroughput,
+                    accessor.getBlock().getRegistryName().toString(),
+                    accessor.getMetadata()
+
+            );
+
             if (ConfigHandler.instance().getConfig(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATA, true))
-                currenttip.add(String.format(VanillaTooltipHandler.metaDataThroughput, accessor.getBlock().getRegistryName().toString(), accessor.getMetadata()));
+
+                currenttip.add(String.format(VanillaTooltipHandler.metaDataWrapper, metaMetaData));
+
         }
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
+++ b/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
@@ -162,6 +162,7 @@ public class ConfigHandler implements IWailaConfigHandler {
 
         VanillaTooltipHandler.modNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_MODNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00A79\u00A7o%s")).getString());
         VanillaTooltipHandler.blockNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_BLOCKNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00a7r\u00a7f%s")).getString());
+        VanillaTooltipHandler.fluidNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_FLUIDNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00a7r\u00a7f%s")).getString());
         VanillaTooltipHandler.entityNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_ENTITYNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00a7r\u00a7f%s")).getString());
         VanillaTooltipHandler.metaDataWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATAWRAPPER, StringEscapeUtils.escapeJava("\u00a77[%s]")).getString());
 

--- a/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
+++ b/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
@@ -160,7 +160,7 @@ public class ConfigHandler implements IWailaConfigHandler {
         OverlayConfig.fontcolor = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_FONTCOLOR, 0xA0A0A0).getInt();
         OverlayConfig.scale = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_SCALE, 100).getInt() / 100.0f;
 
-        VanillaTooltipHandler.modNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_MODNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00A7o\u00A79%s")).getString());
+        VanillaTooltipHandler.modNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_MODNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00A79\u00A7o%s")).getString());
         VanillaTooltipHandler.blockNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_BLOCKNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00a7r\u00a7f%s")).getString());
         VanillaTooltipHandler.entityNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_ENTITYNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00a7r\u00a7f%s")).getString());
         VanillaTooltipHandler.metaDataWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATAWRAPPER, StringEscapeUtils.escapeJava("\u00a77[%s]")).getString());

--- a/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
+++ b/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
@@ -160,7 +160,7 @@ public class ConfigHandler implements IWailaConfigHandler {
         OverlayConfig.fontcolor = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_FONTCOLOR, 0xA0A0A0).getInt();
         OverlayConfig.scale = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_SCALE, 100).getInt() / 100.0f;
 
-        VanillaTooltipHandler.modNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_MODNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00A7e%s")).getString());
+        VanillaTooltipHandler.modNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_MODNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00A7o\u00A79%s")).getString());
         VanillaTooltipHandler.blockNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_BLOCKNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00a7r\u00a7f%s")).getString());
         VanillaTooltipHandler.entityNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_ENTITYNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00a7r\u00a7f%s")).getString());
         VanillaTooltipHandler.metaDataWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATAWRAPPER, StringEscapeUtils.escapeJava("\u00a77[%s]")).getString());

--- a/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
+++ b/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
@@ -163,7 +163,7 @@ public class ConfigHandler implements IWailaConfigHandler {
         VanillaTooltipHandler.modNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_MODNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00A7e%s")).getString());
         VanillaTooltipHandler.blockNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_BLOCKNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00a7r\u00a7f%s")).getString());
         VanillaTooltipHandler.entityNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_ENTITYNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00a7r\u00a7f%s")).getString());
-        VanillaTooltipHandler.metaDataWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATAWRAPPER, StringEscapeUtils.escapeJava("\u00a77[%s:%d]")).getString());
+        VanillaTooltipHandler.metaDataWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATAWRAPPER, StringEscapeUtils.escapeJava("\u00a77[%s]")).getString());
 
         HUDHandlerEntities.nhearts = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_NHEARTS, 20).getInt();
         HUDHandlerEntities.maxhpfortext = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_MAXHP, 40).getInt();

--- a/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
+++ b/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
@@ -161,7 +161,9 @@ public class ConfigHandler implements IWailaConfigHandler {
         OverlayConfig.scale = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_SCALE, 100).getInt() / 100.0f;
 
         VanillaTooltipHandler.modNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_MODNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00A7e%s")).getString());
-        VanillaTooltipHandler.objectNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_OBJECTNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00a7r\u00a7f%s")).getString());
+        VanillaTooltipHandler.blockNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_BLOCKNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00a7r\u00a7f%s")).getString());
+        VanillaTooltipHandler.entityNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_ENTITYNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00a7r\u00a7f%s")).getString());
+        VanillaTooltipHandler.metaDataWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_METADATAWRAPPER, StringEscapeUtils.escapeJava("\u00a77[%s:%d]")).getString());
 
         HUDHandlerEntities.nhearts = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_NHEARTS, 20).getInt();
         HUDHandlerEntities.maxhpfortext = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_MAXHP, 40).getInt();

--- a/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
+++ b/src/main/java/mcp/mobius/waila/api/impl/ConfigHandler.java
@@ -160,7 +160,7 @@ public class ConfigHandler implements IWailaConfigHandler {
         OverlayConfig.fontcolor = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_FONTCOLOR, 0xA0A0A0).getInt();
         OverlayConfig.scale = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_SCALE, 100).getInt() / 100.0f;
 
-        VanillaTooltipHandler.modNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_MODNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00a79\u00a7o%s")).getString());
+        VanillaTooltipHandler.modNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_MODNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00A7e%s")).getString());
         VanillaTooltipHandler.objectNameWrapper = StringEscapeUtils.unescapeJava(config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_OBJECTNAMEWRAPPER, StringEscapeUtils.escapeJava("\u00a7r\u00a7f%s")).getString());
 
         HUDHandlerEntities.nhearts = config.get(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_NHEARTS, 20).getInt();

--- a/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
+++ b/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
@@ -20,8 +20,14 @@ public class VanillaTooltipHandler {
     @SubscribeEvent
     @SideOnly(Side.CLIENT)
     public void tooltipEvent(ItemTooltipEvent event) {
+
         String canonicalName = ModIdentification.nameFromStack(event.getItemStack());
-        if (!Strings.isNullOrEmpty(canonicalName))
-            event.getToolTip().add(String.format(VanillaTooltipHandler.modNameWrapper, canonicalName));
+
+        if (!Strings.isNullOrEmpty(modNameWrapper))
+
+            if (!Strings.isNullOrEmpty(canonicalName))
+            event.getToolTip().add(String.format(modNameWrapper, canonicalName));
+
     }
 }
+

--- a/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
+++ b/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
@@ -9,7 +9,10 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class VanillaTooltipHandler {
 
-    public static String objectNameWrapper = "\u00a7r\u00a7f%s";
+    public static String blockNameWrapper = "\u00a7r\u00a7f%s";
+    public static String entityNameWrapper = "\u00a7r\u00a7f%s";
+
+    public static String metaDataWrapper = "\u00a77[%s:%d]";
 
     public static String modNameWrapper = "\u00a79\u00a7o%s";
 

--- a/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
+++ b/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
@@ -12,7 +12,8 @@ public class VanillaTooltipHandler {
     public static String blockNameWrapper = "\u00a7r\u00a7f%s";
     public static String entityNameWrapper = "\u00a7r\u00a7f%s";
 
-    public static String metaDataWrapper = "\u00a77[%s:%d]";
+    public static String metaDataThroughput = "%s:%d";
+    public static String metaDataWrapper = String.format("\u00a77[%s]", metaDataThroughput);
 
     public static String modNameWrapper = "\u00a79\u00a7o%s";
 

--- a/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
+++ b/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
@@ -23,11 +23,17 @@ public class VanillaTooltipHandler {
 
         String canonicalName = ModIdentification.nameFromStack(event.getItemStack());
 
-        if (!Strings.isNullOrEmpty(modNameWrapper))
+        if (!Strings.isNullOrEmpty(modNameWrapper)) {
 
-            if (!Strings.isNullOrEmpty(canonicalName))
-            event.getToolTip().add(String.format(modNameWrapper, canonicalName));
+            if (!Strings.isNullOrEmpty(canonicalName)) {
+
+                event.getToolTip().add(String.format(modNameWrapper, canonicalName));
+
+            }
+
+        }
 
     }
+
 }
 

--- a/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
+++ b/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
@@ -10,6 +10,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 public class VanillaTooltipHandler {
 
     public static String blockNameWrapper = "\u00a7r\u00a7f%s";
+    public static String fluidNameWrapper = "\u00a7r\u00a7f%s";
     public static String entityNameWrapper = "\u00a7r\u00a7f%s";
 
     public static String metaDataThroughput = "%s:%d";

--- a/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
+++ b/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
@@ -20,17 +20,10 @@ public class VanillaTooltipHandler {
 
     @SubscribeEvent
     @SideOnly(Side.CLIENT)
-    public void tooltipEvent(ItemTooltipEvent event) {
-
-        String canonicalName = ModIdentification.nameFromStack(event.getItemStack());
-
+    public void tooltipEvent(ItemTooltipEvent event) {String canonicalName = ModIdentification.nameFromStack(event.getItemStack());
         if (!Strings.isNullOrEmpty(modNameWrapper) && (!Strings.isNullOrEmpty(canonicalName))) {
-
                 event.getToolTip().add(String.format(modNameWrapper, canonicalName));
-
             }
-
     }
-
 }
 

--- a/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
+++ b/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
@@ -15,7 +15,7 @@ public class VanillaTooltipHandler {
     public static String metaDataThroughput = "%s:%d";
     public static String metaDataWrapper = String.format("\u00a77[%s]", metaDataThroughput);
 
-    public static String modNameWrapper = "\u00A7o\u00A79%s";
+    public static String modNameWrapper = "\u00A79\u00A7o%s";
 
     @SubscribeEvent
     @SideOnly(Side.CLIENT)

--- a/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
+++ b/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
@@ -15,7 +15,7 @@ public class VanillaTooltipHandler {
     public static String metaDataThroughput = "%s:%d";
     public static String metaDataWrapper = String.format("\u00a77[%s]", metaDataThroughput);
 
-    public static String modNameWrapper = "\u00a79\u00a7o%s";
+    public static String modNameWrapper = "\u00A7o\u00A79%s";
 
     @SubscribeEvent
     @SideOnly(Side.CLIENT)

--- a/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
+++ b/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
@@ -23,15 +23,11 @@ public class VanillaTooltipHandler {
 
         String canonicalName = ModIdentification.nameFromStack(event.getItemStack());
 
-        if (!Strings.isNullOrEmpty(modNameWrapper)) {
-
-            if (!Strings.isNullOrEmpty(canonicalName)) {
+        if (!Strings.isNullOrEmpty(modNameWrapper) && (!Strings.isNullOrEmpty(canonicalName))) {
 
                 event.getToolTip().add(String.format(modNameWrapper, canonicalName));
 
             }
-
-        }
 
     }
 

--- a/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
+++ b/src/main/java/mcp/mobius/waila/handlers/VanillaTooltipHandler.java
@@ -21,9 +21,8 @@ public class VanillaTooltipHandler {
     @SubscribeEvent
     @SideOnly(Side.CLIENT)
     public void tooltipEvent(ItemTooltipEvent event) {String canonicalName = ModIdentification.nameFromStack(event.getItemStack());
-        if (!Strings.isNullOrEmpty(modNameWrapper) && (!Strings.isNullOrEmpty(canonicalName))) {
+        if (!Strings.isNullOrEmpty(modNameWrapper) && (!Strings.isNullOrEmpty(canonicalName)))
                 event.getToolTip().add(String.format(modNameWrapper, canonicalName));
-            }
     }
 }
 

--- a/src/main/java/mcp/mobius/waila/overlay/DisplayUtil.java
+++ b/src/main/java/mcp/mobius/waila/overlay/DisplayUtil.java
@@ -166,7 +166,7 @@ public class DisplayUtil {
 
     public static String itemDisplayNameShort(ItemStack itemstack) {
         List<String> list = itemDisplayNameMultiline(itemstack);
-        return String.format(VanillaTooltipHandler.objectNameWrapper, list.get(0));
+        return String.format(VanillaTooltipHandler.blockNameWrapper, list.get(0));
     }
 
     public static void renderIcon(int x, int y, int sx, int sy, IconUI icon) {

--- a/src/main/java/mcp/mobius/waila/utils/Constants.java
+++ b/src/main/java/mcp/mobius/waila/utils/Constants.java
@@ -19,6 +19,7 @@ public final class Constants {
     public static String CFG_WAILA_SHOW = "waila.cfg.show";
     public static String CFG_WAILA_MODNAMEWRAPPER = "waila.cfg.modnamewrapper";
     public static String CFG_WAILA_BLOCKNAMEWRAPPER = "waila.cfg.blocknamewrapper";
+    public static String CFG_WAILA_FLUIDNAMEWRAPPER = "waila.cfg.fluidnamewrapper";
     public static String CFG_WAILA_ENTITYNAMEWRAPPER = "waila.cfg.entitynamewrapper";
     public static String CFG_WAILA_METADATAWRAPPER = "waila.cfg.metadatawrapper";
     public static String CFG_WAILA_MODE = "waila.cfg.showmode";

--- a/src/main/java/mcp/mobius/waila/utils/Constants.java
+++ b/src/main/java/mcp/mobius/waila/utils/Constants.java
@@ -18,7 +18,9 @@ public final class Constants {
     public static boolean CFG_DEFAULT_VALUE = true;
     public static String CFG_WAILA_SHOW = "waila.cfg.show";
     public static String CFG_WAILA_MODNAMEWRAPPER = "waila.cfg.modnamewrapper";
-    public static String CFG_WAILA_OBJECTNAMEWRAPPER = "waila.cfg.objectnamewrapper";
+    public static String CFG_WAILA_BLOCKNAMEWRAPPER = "waila.cfg.blocknamewrapper";
+    public static String CFG_WAILA_ENTITYNAMEWRAPPER = "waila.cfg.entitynamewrapper";
+    public static String CFG_WAILA_METADATAWRAPPER = "waila.cfg.metadatawrapper";
     public static String CFG_WAILA_MODE = "waila.cfg.showmode";
     public static String CFG_WAILA_LIQUID = "waila.cfg.liquid";
     public static String CFG_WAILA_METADATA = "waila.cfg.metadata";

--- a/src/main/resources/assets/waila/lang/en_US.lang
+++ b/src/main/resources/assets/waila/lang/en_US.lang
@@ -82,6 +82,7 @@ hud.msg.green=Green
 hud.msg.red=Red
 hud.msg.black=Black
 
+hud.msg.health=Health
 hud.msg.growth=Growth
 hud.msg.mature=Mature
 hud.msg.off=Off


### PR DESCRIPTION
Entities use same formatting as blocks by default. Meta data defaults to grey without italics; italics suck. And yes, the brackets can be removed/changed.

I was going to make the default mod name colour yellow without italics, but I've reverted to blue with italics for now..

Example of usage:

![2016-10-27_17 23 57](https://cloud.githubusercontent.com/assets/9869940/19776137/d75a1bb4-9c6a-11e6-99d6-45ce8a813de4.png)
![2016-10-27_17 27 37](https://cloud.githubusercontent.com/assets/9869940/19776138/d763ac42-9c6a-11e6-8783-fdd0fbd88963.png)
