### PR TITLE
Add Curse badge/Remove third party permission reference...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Here's What You're Looking At [![Build Status](http://tehnut.info/jenkins/buildStatus/icon?job=HWYLA/1.10)](http://tehnut.info/jenkins/job/HWYLA/job/1.10/) [![License](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-blue.svg)](https://tldrlegal.com/license/creative-commons-attribution-noncommercial-sharealike-4.0-international-(cc-by-nc-sa-4.0))
+# Here's What You're Looking At [![Build Status](http://tehnut.info/jenkins/buildStatus/icon?job=HWYLA/1.10)](http://tehnut.info/jenkins/job/HWYLA/job/1.10/) [![License](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-blue.svg)](https://tldrlegal.com/license/creative-commons-attribution-noncommercial-sharealike-4.0-international-(cc-by-nc-sa-4.0)) [![](http://cf.way2muchnoise.eu/HWYLA.svg)](https://minecraft.curseforge.com/projects/HWYLA)
 
 **HWYLA** (Pronounced "Hwhy-la", similar to "Coo-Hwhip")
 
 A fork of [WAILA](https://minecraft.curseforge.com/projects/waila) by [ProfMobius](https://minecraft.curseforge.com/members/ProfMobius).
 This fork is permitted under the [CC BY-NC-SA 4.0](https://github.com/TehNut/HWYLA/blob/1.10/LICENSE.md) license.
 
-Usage of this mod is allowed in all modpacks, including those hosted on Curse using it as a third party mod.
+Usage of this mod is permitted in all modpacks.
 
 I intend to update this fork quickly and often.
 


### PR DESCRIPTION
Adding Curse badge to readme and removing the third party mod-pack permissions, Now official Curse mod so no longer needed (and slight edit to wording to mirror license wording)