### PR TITLE
Additional Null Pointer Checks

### DIFF
--- a/src/main/java/mcp/mobius/waila/overlay/DecoratorRenderer.java
+++ b/src/main/java/mcp/mobius/waila/overlay/DecoratorRenderer.java
@@ -23,7 +23,8 @@ public class DecoratorRenderer {
     @SubscribeEvent
     @SideOnly(Side.CLIENT)
     public void onRenderWorldLast(RenderWorldLastEvent event) {
-        if (RayTracing.instance().getTarget() == null || RayTracing.instance().getTargetStack().isEmpty())
+        if (RayTracing.instance().getTarget() == null || RayTracing.instance().getTargetStack() == null 
+                || RayTracing.instance().getTargetStack().isEmpty())
             return;
 
         double partialTicks = event.getPartialTicks();

--- a/src/main/java/mcp/mobius/waila/overlay/OverlayRenderer.java
+++ b/src/main/java/mcp/mobius/waila/overlay/OverlayRenderer.java
@@ -40,6 +40,9 @@ public class OverlayRenderer {
         if (RayTracing.instance().getTarget() == null)
             return;
 
+        if (RayTracing.instance().getTargetStack() == null)
+            return;
+
         if (RayTracing.instance().getTarget().typeOfHit == RayTraceResult.Type.BLOCK && !RayTracing.instance().getTargetStack().isEmpty()) {
             renderOverlay(WailaTickHandler.instance().tooltip);
         }


### PR DESCRIPTION
I used a block that extends `BlockBreakable` in one of my mods and didn't override the `getPickBlock` method which caused `RayTracing.instance().getTargetStack()` to return `null`.  

https://github.com/ToroCraft/TeleToro/issues/14

I have fixed the problem in TeleToro, however I thought you might be interested in adding this too to make HWYLA more compatible with other mods, mods created by authors that might not know what they are doing ;)