### PR TITLE
Fix hiding of monster egg blocks

### DIFF
--- a/src/main/java/mcp/mobius/waila/addons/minecraft/HUDHandlerVanilla.java
+++ b/src/main/java/mcp/mobius/waila/addons/minecraft/HUDHandlerVanilla.java
@@ -59,7 +59,13 @@ public class HUDHandlerVanilla extends HUDHandlerBase {
                 case 1:
                     return new ItemStack(Blocks.COBBLESTONE);
                 case 2:
-                    return new ItemStack(Blocks.BRICK_BLOCK);
+                    return new ItemStack(Blocks.STONEBRICK);
+                case 3:
+                    return new ItemStack(Blocks.STONEBRICK, 1, 1);
+                case 4:
+                    return new ItemStack(Blocks.STONEBRICK, 1, 2);
+                case 5:
+                    return new ItemStack(Blocks.STONEBRICK, 1, 3);
                 default:
                     return ItemStack.EMPTY;
             }


### PR DESCRIPTION
It didn't take mossy/cracked/chiseled stone brick into account and it displayed stone bricks as clay bricks.