### PR TITLE
add dummy mod info for common namespace

### DIFF
--- a/src/main/java/mcp/mobius/waila/utils/ModIdentification.java
+++ b/src/main/java/mcp/mobius/waila/utils/ModIdentification.java
@@ -27,6 +27,7 @@ public class ModIdentification {
 
     private static final Map<String, ModMetadata> CONTAINER_CACHE = Maps.newHashMap();
     private static final ModMetadata MC_MOD_INFO = new DummyModMetadata("minecraft", "Minecraft");
+    private static final ModMetadata COMMON_INFO = new DummyModMetadata("c", "Common");
     static {
         CONTAINER_CACHE.put(MC_MOD_INFO.getId(), MC_MOD_INFO);
     }

--- a/src/main/java/mcp/mobius/waila/utils/ModIdentification.java
+++ b/src/main/java/mcp/mobius/waila/utils/ModIdentification.java
@@ -27,9 +27,11 @@ public class ModIdentification {
 
     private static final Map<String, ModMetadata> CONTAINER_CACHE = Maps.newHashMap();
     private static final ModMetadata MC_MOD_INFO = new DummyModMetadata("minecraft", "Minecraft");
-    private static final ModMetadata COMMON_INFO = new DummyModMetadata("c", "Common");
+    private static final ModMetadata COMMON_MOD_INFO = new DummyModMetadata("c", "Common");
+
     static {
         CONTAINER_CACHE.put(MC_MOD_INFO.getId(), MC_MOD_INFO);
+        CONTAINER_CACHE.put(COMMON_MOD_INFO.getId(), COMMON_MOD_INFO);
     }
 
     public static ModMetadata getModInfo(String namespace) {


### PR DESCRIPTION
Cotton registers items added through its API under the `c` namespace, since it's the agreed-on namespace for commonly-shared stuff. Since there's no actual mod that can *ever* have the `c` mod ID (which is why we chose it, mod IDs need to be two or more chars), there needs to be a dummy info for the namespace.