### PR TITLE
(Duplicate, requesting deletion) Various tooltip fixes

### DIFF
--- a/src/main/java/mcp/mobius/waila/addons/minecraft/HUDHandlerVanilla.java
+++ b/src/main/java/mcp/mobius/waila/addons/minecraft/HUDHandlerVanilla.java
@@ -99,13 +99,13 @@ public class HUDHandlerVanilla implements IComponentProvider, IServerDataProvide
 
         if (config.get(PluginMinecraft.CONFIG_REPEATER) && accessor.getBlock() == Blocks.REPEATER) {
             int delay = accessor.getBlockState().get(BlockStateProperties.DELAY_1_4);
-            tooltip.add(new TranslationTextComponent("waila.tooltip.delay", delay));
+            tooltip.add(new TranslationTextComponent("tooltip.waila.delay", delay));
             return;
         }
 
         if (config.get(PluginMinecraft.CONFIG_COMPARATOR) && accessor.getBlock() == Blocks.COMPARATOR) {
             ComparatorMode mode = accessor.getBlockState().get(BlockStateProperties.COMPARATOR_MODE);
-            tooltip.add(new TranslationTextComponent("tooltip.waila.mode", new TranslationTextComponent("tooltip.waila.mode_." + (mode == ComparatorMode.COMPARE ? "comparator" : "subtractor"))));
+            tooltip.add(new TranslationTextComponent("tooltip.waila.mode", new TranslationTextComponent("tooltip.waila.mode_" + (mode == ComparatorMode.COMPARE ? "comparator" : "subtractor"))));
             return;
         }
 

--- a/src/main/java/mcp/mobius/waila/addons/minecraft/PluginMinecraft.java
+++ b/src/main/java/mcp/mobius/waila/addons/minecraft/PluginMinecraft.java
@@ -27,6 +27,7 @@ public class PluginMinecraft implements IWailaPlugin {
     static final ResourceLocation CONFIG_DISPLAY_FURNACE = new ResourceLocation("display_furnace_contents");
     static final ResourceLocation CONFIG_HIDE_SILVERFISH = new ResourceLocation("hide_infestations");
     static final ResourceLocation CONFIG_SPAWNER_TYPE = new ResourceLocation("spawner_type");
+    static final ResourceLocation POTTED_PLANTS = new ResourceLocation("potted_plants");
     static final ResourceLocation CONFIG_CROP_PROGRESS = new ResourceLocation("crop_progress");
     static final ResourceLocation CONFIG_LEVER = new ResourceLocation("lever");
     static final ResourceLocation CONFIG_REPEATER = new ResourceLocation("repeater");
@@ -38,6 +39,7 @@ public class PluginMinecraft implements IWailaPlugin {
     public void register(IRegistrar registrar) {
         registrar.addConfig(CONFIG_DISPLAY_FURNACE, true);
         registrar.addSyncedConfig(CONFIG_HIDE_SILVERFISH, true);
+        registrar.addConfig(POTTED_PLANTS, true);
         registrar.addConfig(CONFIG_SPAWNER_TYPE, true);
         registrar.addConfig(CONFIG_CROP_PROGRESS, true);
         registrar.addConfig(CONFIG_LEVER, true);
@@ -54,13 +56,14 @@ public class PluginMinecraft implements IWailaPlugin {
         registrar.registerStackProvider(HUDHandlerVanilla.INSTANCE, CropsBlock.class);
         registrar.registerComponentProvider(HUDHandlerVanilla.INSTANCE, TooltipPosition.HEAD, SilverfishBlock.class);
         registrar.registerComponentProvider(HUDHandlerVanilla.INSTANCE, TooltipPosition.HEAD, MobSpawnerTileEntity.class);
+        registrar.registerComponentProvider(HUDHandlerVanilla.INSTANCE, TooltipPosition.HEAD, FlowerPotBlock.class);
         registrar.registerComponentProvider(HUDHandlerVanilla.INSTANCE, TooltipPosition.BODY, CropsBlock.class);
         registrar.registerComponentProvider(HUDHandlerVanilla.INSTANCE, TooltipPosition.BODY, StemBlock.class);
         registrar.registerComponentProvider(HUDHandlerVanilla.INSTANCE, TooltipPosition.BODY, CocoaBlock.class);
         registrar.registerComponentProvider(HUDHandlerVanilla.INSTANCE, TooltipPosition.BODY, LeverBlock.class);
         registrar.registerComponentProvider(HUDHandlerVanilla.INSTANCE, TooltipPosition.BODY, RepeaterBlock.class);
         registrar.registerComponentProvider(HUDHandlerVanilla.INSTANCE, TooltipPosition.BODY, ComparatorBlock.class);
-        registrar.registerComponentProvider(HUDHandlerVanilla.INSTANCE, TooltipPosition.BODY, RedstoneBlock.class);
+        registrar.registerComponentProvider(HUDHandlerVanilla.INSTANCE, TooltipPosition.BODY, RedstoneWireBlock.class);
         registrar.registerComponentProvider(HUDHandlerVanilla.INSTANCE, TooltipPosition.BODY, JukeboxTileEntity.class);
         registrar.registerBlockDataProvider(HUDHandlerVanilla.INSTANCE, JukeboxTileEntity.class);
 


### PR DESCRIPTION
- Adds a config (enabled by default) to display flower pots using their block name (#257)
	- `Oak Sapling` -> `Potted Oak Sapling`
- Fixes redstone wire tooltips not being registered to the correct block (#248)
	- `RedstoneBlock.class` -> `RedstoneWireBlock.class`
- Fixes formatting for spawner block names, and prevents potential NPE's with null cached entities
- Fixes records showing `Music Disc` and `Air` as opposed to the record name in the Jukebox tooltip (#250)
	- Sends the music disc item name to the client and looks up the record description
	- Caches the item name registry lookup to avoid performance issues
- Fixes incorrect translation keys for diodes
	- `"waila.tooltip.delay"` -> `"tooltip.waila.delay"`
	- `"tooltip.waila.mode_." +` -> `"tooltip.waila.mode_" +`