### PR TITLE
Render text component instead of String

### DIFF
--- a/src/main/java/mcp/mobius/waila/overlay/Tooltip.java
+++ b/src/main/java/mcp/mobius/waila/overlay/Tooltip.java
@@ -77,7 +77,7 @@ public class Tooltip {
                     xOffset += size.width;
                 }
             } else {
-                client.fontRenderer.drawStringWithShadow(matrixStack, line.getComponent().getString(), position.x, position.y, color.getFontColor());
+                client.fontRenderer.drawStringWithShadow(matrixStack, line.getComponent(), position.x, position.y, color.getFontColor());
             }
             position.y += line.size.height;
         }


### PR DESCRIPTION
This will probably work, unless the MCP name is different for that method signature.  Makes everything not gray.