### PR TITLE
Fix comparison sort method

### DIFF
--- a/src/main/java/mcp/mobius/waila/proxy/ProxyCommon.java
+++ b/src/main/java/mcp/mobius/waila/proxy/ProxyCommon.java
@@ -62,10 +62,13 @@ public class ProxyCommon implements IProxy {
         // Register the rest
         List<Map.Entry<Class<?>, IWailaPlugin>> sortedPlugins = Lists.newArrayList(plugins.entrySet());
         sortedPlugins.sort((o1, o2) -> {
-            if (o1.getKey().getCanonicalName().startsWith("mcp.mobius.waila"))
+            if (o1.getKey().getCanonicalName().startsWith("mcp.mobius.waila") && !o2.getKey().getCanonicalName().startsWith("mcp.mobius.waila")) {
                 return -1;
-
-            return o1.getKey().getCanonicalName().compareToIgnoreCase(o2.getKey().getCanonicalName());
+            } else if (!o1.getKey().getCanonicalName().startsWith("mcp.mobius.waila") && o2.getKey().getCanonicalName().startsWith("mcp.mobius.waila")) {
+                return 1;
+            } else {
+                return o1.getKey().getCanonicalName().compareToIgnoreCase(o2.getKey().getCanonicalName());
+            }
         });
         for (Map.Entry<Class<?>, IWailaPlugin> plugin : sortedPlugins) {
             Waila.LOGGER.info("Registering plugin at {}", plugin.getKey().getCanonicalName());


### PR DESCRIPTION
Fixes https://github.com/TehNut/HWYLA/issues/167

This completes the comparison method by considering all possibilites and avoids `java.lang.IllegalArgumentException: Comparison method violates its general contract!`

Tested on Project Ozone 3. The log displays the expected order of registered plugins (`mcp.mobius.waila.addons.core.PluginCore` is always registered first):

<details>
  <summary>Expand</summary>

```
[17:28:50] [Client thread/INFO]: Registering plugins...
[17:28:50] [Client thread/INFO]: Registering plugin at mcp.mobius.waila.addons.core.PluginCore
[17:28:50] [Client thread/INFO]: Registering plugin at mcp.mobius.waila.addons.capability.PluginCapability
[17:28:50] [Client thread/INFO]: Registering plugin at mcp.mobius.waila.addons.minecraft.PluginMinecraft
[17:28:50] [Client thread/INFO]: Registering plugin at appeng.integration.modules.waila.WailaModule
[17:28:50] [Client thread/INFO]: Registering plugin at blusunrize.immersiveengineering.common.util.compat.waila.IEWailaDataProvider
[17:28:50] [Client thread/INFO]: Registering plugin at cazador.furnaceoverhaul.compat.HwylaPlugin
[17:28:50] [Client thread/INFO]: Registering plugin at com.blakebr0.extendedcrafting.compat.WailaDataProvider
[17:28:50] [Client thread/INFO]: Registering plugin at com.blakebr0.mysticalagradditions.compat.WailaDataProvider
[17:28:50] [Client thread/INFO]: Registering plugin at com.blakebr0.mysticalagriculture.compat.WailaDataProvider
[17:28:50] [Client thread/INFO]: Registering plugin at com.cjm721.overloaded.client.waila.OverloadedWailaPlugin
[17:28:50] [Client thread/INFO]: Registering plugin at com.jaquadro.minecraft.storagedrawers.integration.Waila
[17:28:50] [Client thread/INFO]: Registering plugin at com.mike_caron.mikesmodslib.integrations.WailaCompatibility
[17:28:50] [Client thread/INFO]: Loading Waila integration
[17:28:50] [Client thread/INFO]: Registering plugin at com.mrbysco.wasaila.WailaHandler
[17:28:50] [Client thread/INFO]: Registering plugin at com.progwml6.natura.plugin.waila.PluginWaila
[17:28:50] [Client thread/INFO]: Registering plugin at com.robrit.moofluids.common.plugins.waila.WailaPlugin
[17:28:50] [Client thread/INFO]: WAILA tooltip successfully registered.
[17:28:50] [Client thread/INFO]: Registering plugin at com.zeitheron.hammercore.compat.waila.GetWaila
[17:28:50] [Client thread/INFO]: Waila API hooked!
[17:28:50] [Client thread/INFO]: Registering plugin at elec332.core.compat.waila.WailaCompatHandler
[17:28:50] [Client thread/INFO]: Registering plugin at exnihilocreatio.compatibility.CompatWaila
[17:28:50] [Client thread/INFO]: Registering plugin at extracells.integration.waila.Waila
[17:28:50] [Client thread/INFO]: Registering plugin at jackyy.dimensionaledibles.compat.WailaCompat
[17:28:50] [Client thread/INFO]: Registering plugin at li.cil.oc.integration.waila.BlockDataProvider
[17:28:50] [Client thread/INFO]: Registering plugin at mcjty.lib.compat.waila.WailaCompatibility
[17:28:50] [Client thread/INFO]: Registering plugin at me.desht.pneumaticcraft.common.thirdparty.waila.WailaCallback
[17:28:50] [Client thread/INFO]: Registering plugin at net.bdew.ae2stuff.waila.WailaHandler
[17:28:50] [Client thread/INFO]: Registering plugin at net.blay09.mods.cookingforblockheads.compat.WailaProvider
[17:28:50] [Client thread/INFO]: Registering plugin at net.blay09.mods.waystones.compat.WailaProvider
[17:28:50] [Client thread/INFO]: Registering plugin at net.darkhax.darkutils.addons.waila.DarkUtilsTileProvider
[17:28:50] [Client thread/INFO]: Registering plugin at net.darkhax.wawla.engine.waila.EntityProvider
[17:28:50] [Client thread/INFO]: Registering plugin at net.darkhax.wawla.engine.waila.TileProvider
[17:28:50] [Client thread/INFO]: Registering plugin at omtteam.omlib.compatibility.hwyla.OMLibWailaPlugin
[17:28:50] [Client thread/INFO]: Registering plugin at org.dave.bonsaitrees.compat.Waila.WailaProvider
[17:28:50] [Client thread/INFO]: Enabled support for Waila/Hwyla
[17:28:50] [Client thread/INFO]: Registering plugin at org.icannt.netherendingores.integration.common.compat.WailaCompatibility
[17:28:50] [Client thread/INFO]: Registering plugin at ovh.corail.tombstone.compatibility.IntegrationHwyla
[17:28:50] [Client thread/INFO]: Registering plugin at p455w0rd.danknull.integration.WAILA
[17:28:50] [Client thread/INFO]: Registering plugin at p455w0rd.endermanevo.integration.WAILA
[17:28:50] [Client thread/INFO]: Registering plugin at shadows.ench.compat.EnchHwylaPlugin
[17:28:50] [Client thread/INFO]: Registering plugin at shadows.spawn.compat.SpawnerWailaPlugin
[17:28:50] [Client thread/INFO]: Registering plugin at slimeknights.tconstruct.plugin.waila.WailaRegistrar
[17:28:50] [Client thread/INFO]: Registering plugin at squeek.wailaharvestability.WailaHandler
[17:28:50] [Client thread/INFO]: Registering plugin at team.chisel.common.integration.waila.ChiselDataHandler
[17:28:50] [Client thread/INFO]: Registering plugin at WayofTime.bloodmagic.compat.waila.BloodMagicHwylaPlugin
[17:28:50] [Client thread/INFO]: Registering plugin at xreliquary.compat.waila.WailaCallbackHandler
[17:28:50] [Client thread/INFO]: Starting Waila took 813.2 ms
```
</details>