### PR TITLE
Fix numerical display halving health values

### DIFF
--- a/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
+++ b/src/main/java/mcp/mobius/waila/addons/core/HUDHandlerEntities.java
@@ -25,15 +25,15 @@ public class HUDHandlerEntities implements IEntityComponentProvider {
     public void appendBody(List<ITextComponent> tooltip, IEntityAccessor accessor, IPluginConfig config) {
         if (config.get(PluginCore.CONFIG_SHOW_ENTITY_HEALTH) && accessor.getEntity() instanceof LivingEntity) {
             LivingEntity living = (LivingEntity) accessor.getEntity();
-            float health = living.getHealth() / 2.0F;
-            float maxHealth = living.getMaxHealth() / 2.0F;
+            float health = living.getHealth();
+            float maxHealth = living.getMaxHealth();
 
             if (living.getMaxHealth() > Waila.CONFIG.get().getGeneral().getMaxHealthForRender())
                 tooltip.add(new TranslationTextComponent("tooltip.waila.health", String.format("%.2f", health), String.format("%.2f", maxHealth)));
             else {
                 CompoundNBT healthData = new CompoundNBT();
-                healthData.putFloat("health", health);
-                healthData.putFloat("max", maxHealth);
+                healthData.putFloat("health", health / 2.0F);
+                healthData.putFloat("max", maxHealth / 2.0F);
                 tooltip.add(new RenderableTextComponent(PluginCore.RENDER_ENTITY_HEALTH, healthData));
             }
         }


### PR DESCRIPTION
At present, the numerical display for hp values displays half of the correct value for both current hp and max hp, instead of the correct values.  The values being shown are in hearts instead of hp, despite the bar saying "X/Y Health"
![](https://i.imgur.com/aRz02Ow.png)
This entity has a current hp of `[Apotheosis : Deadly/]: hp: 308.1312255859375` 
and a max hp of `[Apotheosis : Deadly/]: hp: 362.18945`
