### PR TITLE
Update to fabric 1.16.4 and fix config screen crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "com.matthewprenger.cursegradle" version "1.3.0"
-    id 'fabric-loom' version '0.4-SNAPSHOT'
+    id 'fabric-loom' version '0.5-SNAPSHOT'
     id "maven-publish"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ package_group=mcp.mobius.waila
 mod_version=1.9.23
 curse_id=253449
 
-mc_version=1.16.2
-mappings_version=1
-loader_version=0.9.1+build.205
+mc_version=1.16.4
+mappings_version=7
+loader_version=0.10.8
 api_version=0.1.3+
 api_commands_version=1.0.8+
 api_keybinding_version=1.0.0+

--- a/src/main/java/mcp/mobius/waila/gui/GuiConfigPlugins.java
+++ b/src/main/java/mcp/mobius/waila/gui/GuiConfigPlugins.java
@@ -8,6 +8,7 @@ import mcp.mobius.waila.gui.config.value.OptionsEntryValueBoolean;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.text.LiteralText;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Identifier;
 
@@ -25,7 +26,7 @@ public class GuiConfigPlugins extends GuiOptions {
         PluginConfig.INSTANCE.getNamespaces().forEach(namespace -> {
             String translationKey = "config.waila.plugin_" + namespace;
             Set<Identifier> keys = PluginConfig.INSTANCE.getKeys(namespace);
-            options.add(new OptionsEntryButton(translationKey, new ButtonWidget(0, 0, 100, 20, null, w -> {
+            options.add(new OptionsEntryButton(translationKey, new ButtonWidget(0, 0, 100, 20, LiteralText.EMPTY, w -> {
                 client.openScreen(new GuiOptions(GuiConfigPlugins.this, new TranslatableText(translationKey)) {
                     @Override
                     public OptionsListWidget getOptions() {

--- a/src/main/java/mcp/mobius/waila/gui/GuiConfigWaila.java
+++ b/src/main/java/mcp/mobius/waila/gui/GuiConfigWaila.java
@@ -9,6 +9,7 @@ import mcp.mobius.waila.gui.config.value.OptionsEntryValueEnum;
 import mcp.mobius.waila.gui.config.value.OptionsEntryValueInput;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.text.LiteralText;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.Util;
@@ -23,7 +24,7 @@ public class GuiConfigWaila extends GuiOptions {
     @Override
     public OptionsListWidget getOptions() {
         OptionsListWidget options = new OptionsListWidget(this, client, width + 45, height, 32, height - 32, 30, Waila.CONFIG::save);
-        options.add(new OptionsEntryButton(Util.createTranslationKey("config", new Identifier(Waila.MODID, "general")), new ButtonWidget(0, 0, 100, 20, null, w -> {
+        options.add(new OptionsEntryButton(Util.createTranslationKey("config", new Identifier(Waila.MODID, "general")), new ButtonWidget(0, 0, 100, 20, LiteralText.EMPTY, w -> {
             client.openScreen(new GuiOptions(GuiConfigWaila.this, new TranslatableText(Util.createTranslationKey("config", new Identifier(Waila.MODID, "general")))) {
                 @Override
                 public OptionsListWidget getOptions() {
@@ -56,7 +57,7 @@ public class GuiConfigWaila extends GuiOptions {
                 }
             });
         })));
-        options.add(new OptionsEntryButton(Util.createTranslationKey("config", new Identifier(Waila.MODID, "overlay")), new ButtonWidget(0, 0, 100, 20, null, w -> {
+        options.add(new OptionsEntryButton(Util.createTranslationKey("config", new Identifier(Waila.MODID, "overlay")), new ButtonWidget(0, 0, 100, 20, LiteralText.EMPTY, w -> {
             client.openScreen(new GuiOptions(GuiConfigWaila.this, new TranslatableText(Util.createTranslationKey("config", new Identifier(Waila.MODID, "overlay")))) {
                 @Override
                 public OptionsListWidget getOptions() {
@@ -70,7 +71,7 @@ public class GuiConfigWaila extends GuiOptions {
                     options.add(new OptionsEntryValueEnum<>(Util.createTranslationKey("config", new Identifier(Waila.MODID, "overlay_size")), WailaConfig.ConfigOverlay.SizeChoice.values(), Waila.CONFIG.get().getOverlay().getOverlaySize(), val ->
                             Waila.CONFIG.get().getOverlay().setOverlaySize(val)
                     ));
-                    options.add(new OptionsEntryButton(Util.createTranslationKey("config", new Identifier(Waila.MODID, "overlay_color")), new ButtonWidget(0, 0, 100, 20, null, w -> {
+                    options.add(new OptionsEntryButton(Util.createTranslationKey("config", new Identifier(Waila.MODID, "overlay_color")), new ButtonWidget(0, 0, 100, 20, LiteralText.EMPTY, w -> {
                         client.openScreen(new GuiOptions(GuiConfigWaila.this, new TranslatableText(Util.createTranslationKey("config", new Identifier(Waila.MODID, "overlay_color")))) {
                             @Override
                             public OptionsListWidget getOptions() {
@@ -92,7 +93,7 @@ public class GuiConfigWaila extends GuiOptions {
                 }
             });
         })));
-        options.add(new OptionsEntryButton(Util.createTranslationKey("config", new Identifier(Waila.MODID, "formatting")), new ButtonWidget(0, 0, 100, 20, null, w -> {
+        options.add(new OptionsEntryButton(Util.createTranslationKey("config", new Identifier(Waila.MODID, "formatting")), new ButtonWidget(0, 0, 100, 20, LiteralText.EMPTY, w -> {
             client.openScreen(new GuiOptions(GuiConfigWaila.this, new TranslatableText(Util.createTranslationKey("config", new Identifier(Waila.MODID, "overlay")))) {
                 @Override
                 public OptionsListWidget getOptions() {

--- a/src/main/java/mcp/mobius/waila/gui/config/OptionsListWidget.java
+++ b/src/main/java/mcp/mobius/waila/gui/config/OptionsListWidget.java
@@ -45,13 +45,13 @@ public class OptionsListWidget extends ElementListWidget<OptionsListWidget.Entry
         int j = scrollPosX + 6;
         Tessellator tessellator = Tessellator.getInstance();
         BufferBuilder bufferBuilder = tessellator.getBuffer();
-        this.client.getTextureManager().bindTexture(DrawableHelper.BACKGROUND_TEXTURE);
+        this.client.getTextureManager().bindTexture(DrawableHelper.OPTIONS_BACKGROUND_TEXTURE);
         RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
         int rowLeft = this.getRowLeft();
         int scrollJump = this.top + 4 - (int)this.getScrollAmount();
 
         this.renderList(matrices, rowLeft, scrollJump, mouseX, mouseY, delta);
-        this.client.getTextureManager().bindTexture(DrawableHelper.BACKGROUND_TEXTURE);
+        this.client.getTextureManager().bindTexture(DrawableHelper.OPTIONS_BACKGROUND_TEXTURE);
         RenderSystem.enableDepthTest();
         RenderSystem.depthFunc(519);
         bufferBuilder.begin(7, VertexFormats.POSITION_TEXTURE_COLOR);

--- a/src/main/java/mcp/mobius/waila/overlay/RayTracing.java
+++ b/src/main/java/mcp/mobius/waila/overlay/RayTracing.java
@@ -18,7 +18,7 @@ import net.minecraft.util.hit.EntityHitResult;
 import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.RayTraceContext;
+import net.minecraft.world.RaycastContext;
 import net.minecraft.world.World;
 
 import java.util.Collection;
@@ -64,9 +64,9 @@ public class RayTracing {
         Vec3d lookVector = entity.getRotationVec(partialTicks);
         Vec3d traceEnd = eyePosition.add(lookVector.x * playerReach, lookVector.y * playerReach, lookVector.z * playerReach);
 
-        RayTraceContext.FluidHandling fluidView = Waila.CONFIG.get().getGeneral().shouldDisplayFluids() ? RayTraceContext.FluidHandling.SOURCE_ONLY : RayTraceContext.FluidHandling.NONE;
-        RayTraceContext context = new RayTraceContext(eyePosition, traceEnd, RayTraceContext.ShapeType.OUTLINE, fluidView, entity);
-        return entity.getEntityWorld().rayTrace(context);
+        RaycastContext.FluidHandling fluidView = Waila.CONFIG.get().getGeneral().shouldDisplayFluids() ? RaycastContext.FluidHandling.SOURCE_ONLY : RaycastContext.FluidHandling.NONE;
+        RaycastContext context = new RaycastContext(eyePosition, traceEnd, RaycastContext.ShapeType.OUTLINE, fluidView, entity);
+        return entity.getEntityWorld().raycast(context);
     }
 
     public ItemStack getIdentifierStack() {


### PR DESCRIPTION
Fixes #305 by using `LiteralText.EMPTY` instead of `null` when creating `ButtonWidget`
<details>
  <summary>I also updated it to loom 0.5 since it failed to build on 0.4 ¯\_(ツ)_/¯</summary>

  ```
  3:15:31 PM: Executing task 'build'...


> Configure project :
Fabric Loom: 0.4.33 Build(jenkins #33)
:setting up loom dependencies
:setting up mappings (yarn 1.16.4+build.7)
Configuring compiler arguments for Java

> Task :compileJava
2020-11-18 15:15:39,408 Execution worker for ':' WARN Unable to instantiate org.fusesource.jansi.WindowsAnsiOutputStream
Note: SpongePowered MIXIN Annotation Processor Version=0.8.2
Note: ObfuscationServiceFabric supports type: "official:intermediary"
Note: ObfuscationServiceFabric supports type: "official:named"
Note: ObfuscationServiceFabric supports type: "intermediary:official"
Note: ObfuscationServiceFabric supports type: "intermediary:named"
Note: ObfuscationServiceFabric supports type: "named:official"
Note: ObfuscationServiceFabric supports type: "named:intermediary"
Note: ObfuscationServiceMCP supports type: "searge"
Note: ObfuscationServiceMCP supports type: "notch"
Note: Loading named:intermediary mappings from C:\Users\bai\.gradle\caches\fabric-loom\mappings\yarn-1.16.4+build.7-v2.tiny
Note: Writing refmap to E:\deirn\idea\HWYLA\build\classes\java\main\hwyla-refmap.json
Note: Writing refmap to E:\deirn\idea\HWYLA\build\classes\java\main\hwyla-refmap.json
Note: Writing named:intermediary output TinyMappings to E:\deirn\idea\HWYLA\build\loom-cache\mixin-map-1.16.4-1.16.4+build.7-v2.tiny
Note: Writing refmap to E:\deirn\idea\HWYLA\build\classes\java\main\hwyla-refmap.json
Note: Writing refmap to E:\deirn\idea\HWYLA\build\classes\java\main\hwyla-refmap.json
Note: Writing named:intermediary output TinyMappings to E:\deirn\idea\HWYLA\build\loom-cache\mixin-map-1.16.4-1.16.4+build.7-v2.tiny
E:\deirn\idea\HWYLA\src\main\java\mcp\mobius\waila\gui\config\OptionsListWidget.java:21: error: cannot access Nullable
public class OptionsListWidget extends ElementListWidget<OptionsListWidget.Entry> {
       ^
  class file for org.jetbrains.annotations.Nullable not found
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 error

> Task :compileJava FAILED

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.4.1/userguide/command_line_interface.html#sec:command_line_warnings
1 actionable task: 1 executed

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileJava'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 9s
3:15:41 PM: Task execution finished 'build'.

  ```
</details>


everything else is just works